### PR TITLE
Fix: Add return to guard statement in checkValue function

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -1,0 +1,11 @@
+func checkValue(_ value: Int?) {
+    guard let unwrappedValue = value else {
+        print("Value is nil")
+        return // Added return statement
+    }
+    print("Value is \(unwrappedValue)")
+}
+
+// Call the function to demonstrate the issue (optional)
+checkValue(nil)
+checkValue(5)


### PR DESCRIPTION
The guard statement in the checkValue function was missing a return or throw statement in its else block, causing a "guard body must not fall through" error. This commit adds a return statement to correctly exit the scope when the guard condition is not met.