### PR TITLE
Update Bangkok Travel Guide with 3 New Local Districts

### DIFF
--- a/曼谷旅遊點推薦.md
+++ b/曼谷旅遊點推薦.md
@@ -2,7 +2,7 @@
 
 這份指南致力於挖掘泰國當地人（透過 Pantip 論壇、社群討論）推薦的旅遊景點，避開過度商業化的觀光陷阱，提供道地的曼谷體驗。
 
-> **狀態**：完成 (經過 4 輪循環分析)
+> **狀態**：更新完成 (Phase 2 - 經過 8 輪循環分析)
 
 ## 📂 推薦景點分類
 
@@ -38,13 +38,43 @@
 *   **城市綠洲 (Urban Oasis)**:
     *   **Benjakitti Forest Park (班嘉奇蒂森林公園)**: 擴建後的森林園區是目前曼谷最受歡迎的傍晚去處。擁有巨大的濕地步道 (Skywalk)，適合在下午 5 點左右來散步看夕陽，避開白天的酷熱。
 
-### 4. 交通貼士 (Transportation Tips)
+### 4. Ladprao & Nak Niwat (Residential Hipster & Green Cafes)
+真正的曼谷後花園，遠離遊客，充滿設計感的獨棟咖啡廳與綠意。
+
+*   **Nak Niwat Road (ถนนนาคนิวาส)**: 許多明星與設計師居住的區域，咖啡廳水準極高。
+    *   **Forestpresso**: 被綠植包圍的溫室咖啡廳，彷彿置身熱帶雨林。
+    *   **Wood Cafe**: 全木造溫馨小屋，提供像家一樣的泰式簡餐與蛋糕。
+    *   **Norma**: 極簡風格的新晉網紅店，光影設計極佳。
+*   **Chok Chai 4 (โชคชัย 4)**: 與 Nak Niwat 平行的美食戰區，越夜越熱鬧。
+    *   **Nai Bai Fish Noodle (ก๋วยเตี๋ยวปลานายใบ้)**: 在地人從小吃到大的魚丸麵。
+    *   **Gong Prab Tom Yum Noodle**: 位於警察局對面的傳奇酸辣麵，配上炸豬皮(Crackling)是絕配。
+
+### 5. Srinakarin & Bang Na (Vintage Markets & Active Lifestyle)
+曼谷東部的生活風格中心，適合喜歡戶外活動與復古淘寶的旅人。
+
+*   **Nong Bon Water Sports Center (ศูนย์กีฬาทางน้ำบึงหนองบอน)**: 允許帶寵物的湖畔公園，擁有絕美夕陽與環湖自行車道，是曼谷的「Active Lifestyle」代表。
+*   **Talad Rot Fai Srinakarin (席娜卡琳火車夜市)**: 最原汁原味的火車夜市，佔地廣大，充滿古董車、美式復古與在地小吃，比 Jodd Fairs 更具靈魂。
+*   **Paradise Park - Seri Market**: 剛翻新的老牌商場，地下的 Seri Market 匯集了許多老字號美食。
+
+### 6. Nonthaburi & Koh Kret (Riverside Craft Culture)
+曼谷近郊的陶瓷島，保留了孟族(Mon)傳統與慢活步調，是週末一日遊首選。
+
+*   **Koh Kret (เกาะเกร็ด)**: 昭披耶河上的沙洲島，沒有汽車，只能騎腳踏車或步行。
+    *   **Chit Beer**: 泰國精釀啤酒教父的傳奇基地，週末人潮洶湧，可坐在河邊喝現拉啤酒。
+    *   **Baan Lek Tee 1 (No. 1 Coffee)**: 藏身於高腳屋內的傳統咖啡店，用陶土杯裝飲料，價格親民。
+    *   **Rong Si Studio**: 舊碾米廠改建的河畔餐廳，保留工業風結構，適合傍晚看日落。
+
+### 7. 交通貼士 (Transportation Tips)
 *   **MuvMi App**: 在 Old Town (老城區)、Ari、Chula (朱拉隆功) 等區域移動的神器。這是一個電動嘟嘟車共乘服務，比一般嘟嘟車便宜且不會亂喊價。
 *   **Chao Phraya Express Boat (藍旗/橘旗)**: 前往 Wang Lang, Wat Arun, Tha Maharaj, Talad Noi (Marine Dept Pier) 最方便的方式，還能欣賞河景。
+*   **MRT Yellow Line (黃線)**: 連接 Ladprao (Lat Phrao 71, Chok Chai 4) 與 Srinakarin (Suan Luang Rama IX) 的重要單軌電車，讓這些在地生活圈變得容易抵達。
+*   **Chao Phraya Express Boat (Green Flag)**: 週末限定的綠旗船，可從 Sathorn 直接前往 Koh Kret (Pak Kret Pier)。
 
 ---
 
 ## 🔄 思考與決策紀錄 (Research Log)
+
+### Phase 1: 基礎建立 (Cycles 1-4)
 
 ### 🌀 第 1 輪循環：廣泛搜尋與在地共識建立
 *   **分析結果**：
@@ -72,3 +102,30 @@
     1.  **新一代美食街**：**Ban Tad Thong** 已確立其地位，擁有 **Jeh O** (排隊名店) 與 **Nueng Nom Nua** (甜點) 等流量保證，是目前取代 Yaowarat 的最佳選擇。
     2.  **交通關鍵**：對於這類非捷運直達的區域 (Old Town, Ban Tad Thong)，**MuvMi** 是當地人最推薦的移動工具。
 *   **最終產出**：完成包含老城創意、在地美食、質感夜生活與交通建議的全方位指南。
+
+### Phase 2: 生活風格擴展 (Cycles 5-8)
+
+### 🌀 第 5 輪循環：尋找老城以外的在地生活感 (Beyond Old Town)
+*   **分析結果**：
+    1.  **趨勢觀察**：隨著 **MRT 黃線** 開通，**Ladprao (Lat Phrao)** 與 **Nak Niwat** 區域成為曼谷年輕人新的週末據點，關鍵字是「綠意 (Greenery)」與「獨棟咖啡廳 (Standalone Cafe)」。
+*   **決策**：鎖定 Ladprao 71 / Nak Niwat 進行深度挖掘。
+
+### 🌀 第 6 輪循環：區域深度挖掘 (Ladprao Deep Dive)
+*   **執行動作**：搜尋該區的具體店家與美食分佈。
+*   **分析結果**：
+    1.  **雙面性格**：Nak Niwat 主打「精緻咖啡 (Forestpresso, Wood Cafe)」，而平行的 Chok Chai 4 則是「平價街頭美食 (Nai Bai, Gong Prab)」的戰場。
+*   **決策**：尋找一個風格強烈對比的區域（例如：復古/戶外）。
+
+### 🌀 第 7 輪循環：復古與戶外生活 (Vintage & Active Lifestyle)
+*   **執行動作**：搜尋曼谷東部 (Srinakarin/Bang Na) 的熱門關鍵字。
+*   **分析結果**：
+    1.  **生活風格轉變**：**Nong Bon Water Sports Center** 因「寵物友善」與「水上活動」爆紅，成為曼谷的戶外綠肺。
+    2.  **復古不死**：**Talad Rot Fai Srinakarin** 依然是古著愛好者的聖地，與市區的商業夜市形成強烈對比。
+*   **決策**：補完最後一塊拼圖「河岸與精釀文化」。
+
+### 🌀 第 8 輪循環：河岸慢活與精釀 (Riverside Slow Life)
+*   **執行動作**：確認 **Nonthaburi / Koh Kret** 的店家現況。
+*   **分析結果**：
+    1.  **精釀傳奇**：**Chit Beer** 依然是島上的靈魂，帶動了周邊 **Rong Si Studio** 等文創餐飲的發展。
+    2.  **交通紅利**：綠旗船與捷運紫線讓前往暖武里變得不再困難。
+*   **最終產出**：完成了從「市中心文青」到「近郊慢活」的完整光譜。


### PR DESCRIPTION
Expanded the Bangkok local travel guide with 3 new major districts based on 4 cycles of research into local Thai trends.
Focus areas:
1. Ladprao/Nak Niwat (Cafe hopping, Greenery)
2. Srinakarin (Vintage markets, Water sports)
3. Koh Kret (Craft beer, Pottery, Riverside)
Methodology: Analyzed local sentiment to identify gaps in the previous guide (which focused on Old Town & Food).
Result: A more comprehensive guide covering diverse lifestyles (Cafe, Active, Vintage, River).

---
*PR created automatically by Jules for task [6914198164565502946](https://jules.google.com/task/6914198164565502946) started by @jacky09299*